### PR TITLE
Made explicit Override

### DIFF
--- a/C++/Polymorphism.cpp
+++ b/C++/Polymorphism.cpp
@@ -11,7 +11,7 @@ public:
 class derived:public abc
 {
 public:
-    void show()
+    void show() override
     {
         cout<<"Derived\n";
     }


### PR DESCRIPTION
It's better to be explicit with overridedurin inherutance from virtual base classes

----

C++
