### PR TITLE
Add clear-docker-container.sh

### DIFF
--- a/Bash/clear-docker-containers.sh
+++ b/Bash/clear-docker-containers.sh
@@ -1,0 +1,1 @@
+docker ps -a --format={{.ID}} | tr '\n' ' ' | xargs docker rm


### PR DESCRIPTION
### What the program do ?
TL;DR it'll get rid of all Docker containers that didn't self-destroy after run (ps -a)

- It grabs the output from `docker ps -a` and only grabs the ID of the container.
- It makes sure the output is a one-liner by using `tr`
- it pipes the output of this to `docker rm` by using `xargs`

----

### In what programming language it is written?

Bash
